### PR TITLE
Add KaChiKa to Flashcard Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -271,6 +271,7 @@ Building a strong vocabulary is crucial for effective communication. These resou
 - [Anki][anki-url] - Flashcard app using spaced repetition for efficient vocabulary memorization.
 - [Memrise](https://www.memrise.com/) - User-created vocabulary lists with mnemonics and spaced repetition.
 - [Quizlet](https://quizlet.com/) - Create and study flashcard sets with various learning modes.
+- [KaChiKa](https://kachika.app/) - Snap a photo of any object to extract English vocabulary in real-life context, with FSRS-based flashcards.
 
 #### Dictionary Resources 📚
 - [Forvo](https://forvo.com/) - Native speaker pronunciations of words from different English-speaking regions.


### PR DESCRIPTION
## Summary

Adds [KaChiKa](https://kachika.app/) to the **Vocabulary → Study Tools → Flashcard Apps** section.

KaChiKa is an AI-powered photo-to-flashcard app for language learners. Snap a photo of anything — a coffee cup, a street sign, a cat — and KaChiKa extracts the English vocabulary, generates real-world example sentences, and schedules reviews using [FSRS](https://github.com/open-spaced-repetition/fsrs4anki) (Free Spaced Repetition Scheduler).

It complements Anki / Memrise / Quizlet by addressing a different use case: **learning vocabulary in the context of your daily life** rather than from pre-built decks.

### Why it belongs in this list
- Free with no ads, available on iOS, Android (also APK)
- All photos stored **locally on device** — no upload, privacy-first
- Uses FSRS spaced repetition with forgetting-curve scheduling
- Supports English as the primary learning language (also French, Korean, Italian, Spanish, Japanese, Chinese)

### Checklist
- [x] Entry added in alphabetical / topical fit position
- [x] Format matches existing entries: `- [Name](URL) - One-line description.`
- [x] Description is factual, no marketing fluff
- [x] Tool is actively maintained and publicly available