### PR TITLE
Add Pronounce (developer-jargon pronunciation dictionary) to Dictionary Resources

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -282,6 +282,7 @@ Building a strong vocabulary is crucial for effective communication. These resou
 - [Linguee](https://www.linguee.com/) - Context-rich dictionary with real-world usage examples.
 - [ReversoContext](https://context.reverso.net/translation) - See words and phrases used in authentic contexts.
 - [Word Orb](https://wordorb.ai) - 162,253 English words with IPA pronunciation, etymology, part of speech, and 601,143 translations across 47 languages. Free anonymous tier, HTTPS, CORS enabled — also usable as a programmatic dictionary API.
+- [Pronounce](https://pronounce.renlab.ai/) - Pronunciation dictionary for tech and developer jargon (kubectl, nginx, GIF, JSON) — 1,650+ entries with IPA, audio, and source citations, plus a quiz mode. Free, no install; useful for non-native engineers.
 
 ## Tools
 


### PR DESCRIPTION
## What this adds

[Pronounce](https://pronounce.renlab.ai/) — a free, in-browser pronunciation dictionary focused on tech/developer jargon (kubectl, nginx, GIF, JSON, YAML…).

- 1,650+ entries, each with IPA, a plain-English respelling, pre-rendered audio, and a cited source for where the pronunciation comes from
- Quiz mode for self-testing
- English and 中文 versions
- Free, no install/signup; open source (MIT) on [GitHub](https://github.com/anzy-renlab-ai/pronounce)

## Why it fits this list

Placed under **Vocabulary → Dictionary Resources** alongside Forvo and Word Orb. General dictionaries rarely cover programmer vocabulary (nobody agrees on "kubectl"), so this fills a gap for professionals improving English for work — especially non-native engineers.

Disclosure: I maintain the project. Happy to adjust wording, placement, or length to match the list's style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)