### PR TITLE
Add Sink In app to Flashcard Apps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -273,6 +273,7 @@ Building a strong vocabulary is crucial for effective communication. These resou
 - [Memrise](https://www.memrise.com/) - User-created vocabulary lists with mnemonics and spaced repetition.
 - [Quizlet](https://quizlet.com/) - Create and study flashcard sets with various learning modes.
 - [KaChiKa](https://kachika.app/) - Snap a photo of any object to extract English vocabulary in real-life context, with FSRS-based flashcards.
+- [Sink In](https://pomisoft.dev/sink-in) - Phrasal verbs as a system. The app has animated illustrations and flashcards
 
 #### Dictionary Resources 📚
 - [Forvo](https://forvo.com/) - Native speaker pronunciations of words from different English-speaking regions.


### PR DESCRIPTION
## Summary

Adds **Sink In** to the **Vocabulary → Study Tools → Flashcard Apps** section.

Sink In is a mobile app for learning English phrasal verbs through structured examples, review, and visual memory aids. It focuses on helping learners understand phrasal verbs in context rather than memorizing isolated translations.

## Why it belongs in this list

* Designed specifically for English learners working on phrasal verbs
* Uses example-based learning and review to help learners remember usage patterns
* Fits the flashcard/study-tools section alongside other vocabulary practice apps
* Publicly available as a mobile app

## Checklist

* [x] Entry added in the relevant section
* [x] Format matches existing entries
* [x] Description is factual and concise
* [x] Resource is publicly available
